### PR TITLE
feat(binding): immediately update the target if the Observable has a BehaviorSubject-like current value member

### DIFF
--- a/src/async-binding.ts
+++ b/src/async-binding.ts
@@ -42,6 +42,13 @@ export class asyncBindingBehavior {
             : () => { binding.originalupdateTarget(options && options.property ? this.getPropByPath(options.error, options.property) : options.error); }
           : undefined;
 
+        // Immediately update the target if the Observable has a BehaviorSubject-like current value member
+        if ("value" in a) {
+          binding.originalupdateTarget((a as any).value)
+        } else if (typeof (a as any).getValue === "function") {
+          binding.originalupdateTarget((a as any).getValue())
+        }
+
         binding._subscription = a.subscribe(
           (res) => {
             binding.originalupdateTarget(options && options.property ? this.getPropByPath(res, options.property) : res);


### PR DESCRIPTION
Hi Vildan. As the title says, this change ensures that the target is immediately updated if the Observable has a BehaviorSubject-like current value member.