### PR TITLE
Unsubscribe from previous subscription

### DIFF
--- a/src/async-binding.ts
+++ b/src/async-binding.ts
@@ -27,6 +27,11 @@ export class asyncBindingBehavior {
     binding.originalupdateTarget = binding.updateTarget || (() => {});
 
     binding.updateTarget = (a) => {
+      if (binding._subscription &&
+        typeof binding._subscription.unsubscribe === "function") {
+        binding._subscription.unsubscribe();
+      }
+      
       if (a && typeof a.then === "function") {
         a.then((res: any) => binding.originalupdateTarget(options && options.property ? this.getPropByPath(res, options.property) : res));
         


### PR DESCRIPTION
When `updateTarget` is called multiple times, new subscriptions are created as a result of line 50. However reference to them is lost forever. It causes error messages, where `binding.originalupdateTarget` is undefined, and potentially could cause memory leaks.